### PR TITLE
Require empty hand to use Quick Deposit upgrade

### DIFF
--- a/src/main/java/gr8pefish/ironbackpacks/events/ForgeEventHandler.java
+++ b/src/main/java/gr8pefish/ironbackpacks/events/ForgeEventHandler.java
@@ -260,9 +260,14 @@ public class ForgeEventHandler {
 
             EntityPlayer player = event.getEntityPlayer();
             ItemStack itemstack = IronBackpacksCapabilities.getWornBackpack(event.getEntityPlayer()); //check equipped pack
+            ItemStack heldItemMainhand = player.getHeldItemMainhand();
+            ItemStack heldItemOffhand = player.getHeldItemOffhand();
+//            boolean canDeposit = heldItemMainhand == null && (heldItemOffhand == null || {CHECK_IF_CAN_BE_PLACED_OR_USED});
+            boolean canDeposit = heldItemMainhand == null; // Not checking for offhand is great if you're holding a shield/tool, bad if you're holding a block
+            
             boolean openAltGui = true;
 
-            if (player.isSneaking() && itemstack != null) { //only do it when player is sneaking and has a backpack equipped
+            if (player.isSneaking() && itemstack != null && canDeposit) { //only do it with empty hands when player is sneaking and has a backpack equipped
 
                 World world = event.getWorld();
                 BlockPos pos = event.getPos();


### PR DESCRIPTION
A quick fix for #121 
This solution does not check the offhand, this is to allow it to work
when holding shields/tools/etc. The downside is if you have a block in
your offhand it will quick-deposit AND place the block.
If someone knows how you would go about properly checking if the offhand can be "used" or "placed", that would be an excellent addition and would perfect this fix.

Line 265 is a template for how that check may be done, it doesn't have to be used and can be removed if desired.

Infact, if that "can be used" check could be done on both mainhand and offhand, that would be even better (could quick-deposit a mining bag while holding a pickaxe, for instance)