### PR TITLE
Also check for raytrace failure in block place event handler

### DIFF
--- a/src/main/java/gr8pefish/ironbackpacks/events/ForgeEventHandler.java
+++ b/src/main/java/gr8pefish/ironbackpacks/events/ForgeEventHandler.java
@@ -280,6 +280,7 @@ public class ForgeEventHandler {
 
             //ray trace the block placed
             RayTraceResult rayTraceResult = event.getWorld().rayTraceBlocks(event.getPlayer().getPositionVector(), event.getPlayer().getLookVec());
+            if (rayTraceResult == null) return; //didn't raytrace correctly, return
             //get the block as an itemstack
             ItemStack itemStackPlaced = event.getPlacedBlock().getBlock().getPickBlock(event.getPlacedBlock(), rayTraceResult, event.getWorld(), event.getPos(), event.getPlayer());
 


### PR DESCRIPTION
Sometimes this fails too (cough cough TE ducts), which causes really weird dupe bugs in the right circumstances.