### PR TITLE
Fix canTakeStack handling for player inventory with backpack slot.

### DIFF
--- a/src/main/java/gr8pefish/ironbackpacks/container/ContainerBackpack.java
+++ b/src/main/java/gr8pefish/ironbackpacks/container/ContainerBackpack.java
@@ -208,7 +208,12 @@ public class ContainerBackpack extends Container {
         //Hotbar
         yOffset += getBufferHotbar();
         for (int x = 0; x < 9; x++) {
-            Slot slot = addSlotToContainer(new Slot(inventoryPlayer, x, xOffset + x * 18, yOffset));
+            Slot slot = addSlotToContainer(new Slot(inventoryPlayer, x, xOffset + x * 18, yOffset) {
+                @Override
+                public boolean canTakeStack(final EntityPlayer playerIn) {
+                    return slotNumber != blocked;
+                }
+            });
             if (x == inventoryPlayer.currentItem)
                 blocked = slot.slotNumber;
         }


### PR DESCRIPTION
CanTakeStack should return false for the slot containing the backpack when the backpack container
is open. This means that tools that inspect the inventory will not consider the backpack slot for reading or
writing. This means inventorysorter (amongst others) won't destroy the backpack if you accidentally sort
your hotbar with a backpack open.